### PR TITLE
Replace library chartLine4 with working API

### DIFF
--- a/charts/library/chartLine4.json
+++ b/charts/library/chartLine4.json
@@ -1,47 +1,46 @@
 {
     "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
 
-
     "description": "Chart that uses repeated layers to make multiple calls to an API",
 
-
     "title": {
-      "text": "Covid-19 - cases",
-      "subtitle":"Cumulative cases. Source: Covid19API.com",
+      "text": "Unemployment - 3 Countries",
+      "subtitle":"% rate | Source: STATCAN, FRED, ONS via ECO API",
       "subtitleFontStyle":"italic",
       "subtitleFontSize":10,
       "anchor": "start",
       "color": "black"
     },
 
-
     "height":300,
     "width":270,
 
-    
     "encoding": {
-      "x": {"field": "Date", "type": "temporal", "title": null, "axis": {"grid": false}},
-      "y": {"field": "Cases", "type": "quantitative", "title": null, "axis": {"grid": false}},
+      "x": {"field": "date", "type": "temporal", "title": null, "axis": {"grid": false}},
+      "y": {"field": "value", "type": "quantitative", "title": null, "axis": {"grid": false}},
       "color":{"field":"Country", "title":null, "legend":{"orient": "top-left"}}
     },
 
-
-
     "layer": [
       
-      {"data": {"url": "https://api.covid19api.com/total/country/korea-south/status/confirmed"},
+      {"data": {"url": "https://api.economicsobservatory.com/gbr/unem?vega"},
+      "transform": [
+        {"calculate": "'United Kingdom'", "as": "Country"}
+      ],
       "mark": {"type":"line", "color":"red"}
       },
 
-      {"data": {"url": "https://api.covid19api.com/total/country/japan/status/confirmed"},
+      {"data": {"url": "https://api.economicsobservatory.com/can/unem?vega"},
+      "transform": [
+        {"calculate": "'Canada'", "as": "Country"}
+      ],
       "mark": {"type":"line", "color":"green"}
       },
 
-      {"data": {"url": "https://api.covid19api.com/total/country/spain/status/confirmed"},
-      "mark": {"type":"line", "color":"blue"}
-      },
-
-      {"data": {"url": "https://api.covid19api.com/total/country/italy/status/confirmed"},
+      {"data": {"url": "https://api.economicsobservatory.com/usa/unem?vega"},
+      "transform": [
+        {"calculate": "'United States'", "as": "Country"}
+      ],
       "mark": {"type":"line", "color":"red"}
       }
     ]

--- a/charts/library/chartLine4_brokenAPI.json
+++ b/charts/library/chartLine4_brokenAPI.json
@@ -1,0 +1,48 @@
+{
+    "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+
+
+    "description": "Chart that uses repeated layers to make multiple calls to an API",
+
+
+    "title": {
+      "text": "Covid-19 - cases",
+      "subtitle":"Cumulative cases. Source: Covid19API.com",
+      "subtitleFontStyle":"italic",
+      "subtitleFontSize":10,
+      "anchor": "start",
+      "color": "black"
+    },
+
+
+    "height":300,
+    "width":270,
+
+    
+    "encoding": {
+      "x": {"field": "Date", "type": "temporal", "title": null, "axis": {"grid": false}},
+      "y": {"field": "Cases", "type": "quantitative", "title": null, "axis": {"grid": false}},
+      "color":{"field":"Country", "title":null, "legend":{"orient": "top-left"}}
+    },
+
+
+
+    "layer": [
+      
+      {"data": {"url": "https://api.covid19api.com/total/country/korea-south/status/confirmed"},
+      "mark": {"type":"line", "color":"red"}
+      },
+
+      {"data": {"url": "https://api.covid19api.com/total/country/japan/status/confirmed"},
+      "mark": {"type":"line", "color":"green"}
+      },
+
+      {"data": {"url": "https://api.covid19api.com/total/country/spain/status/confirmed"},
+      "mark": {"type":"line", "color":"blue"}
+      },
+
+      {"data": {"url": "https://api.covid19api.com/total/country/italy/status/confirmed"},
+      "mark": {"type":"line", "color":"red"}
+      }
+    ]
+}

--- a/library.html
+++ b/library.html
@@ -119,16 +119,16 @@
 
         <div class="grid_item">
             <p><strong>Many lines | Multiple sources</strong></p>
-            <p>Some APIs return only one series. This chart runs from JSON data, and uses "layers" to add each country. It is in effect four charts, one for each country, overlaid on one another.</p>
+            <p>Some APIs return only one series. This chart runs from JSON data from the new Economics Observatory API, and uses "layers" to add each country. Each "layer" uses "calculate" to add the country name to each set of country data. It is in effect three charts, one for each country, overlaid on one another.</p>
             <hr>
             <span style="display:block; height: 10px;"></span>
             <div id="chartLine4"></div>
             <span style="display:block; height: 10px;"></span>
             <hr> 
-            <a class="libraryButton" href="https://api.covid19api.com/total/country/korea-south/status/confirmed">Data</a>
+            <a class="libraryButton" href="https://api.economicsobservatory.com/gbr/unem">Data</a>
             <a class="libraryButton" href="https://github.com/RDeconomist/RDeconomist.github.io/blob/main/charts/library/chartLine4.json">Code</a>
-            <a class="libraryButton" href="korea">Dashboard</a>
-            <a class="libraryButtonAPI" href="https://api.covid19api.com">API</a>    
+            <a class="libraryButton" href="jobs">Dashboard</a>
+            <a class="libraryButtonAPI" href="https://www.economicsobservatory.com/data-hub">API</a>    
                        
         </div>
 


### PR DESCRIPTION
Chart 4 combines covid data for different countries from multiple API endpoints. This api is now inactive so chart is breaking on page and cannot see subsequent charts. These changes rename the broken json spec, replacing chartLine4 with same type of chart, pulling unemployment data from 3 countries on ECO API. HTML grid item has also been updated with new description and button links.